### PR TITLE
feat: load preset by name instead of path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,11 @@ jobs:
   commitlint:
     name: Lint commit messages
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     steps:
-      # Add this step to check if the repository is accessible
-      # To be removed once the repository is public
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-        continue-on-error: true
-      - name: Warn if repository not accessible
-        if: steps.checkout.outcome == 'failure'
-        run: echo "::warning::Repository not accessible, skipping commitlint"
-      - name: Lint commit messages
-        if: steps.checkout.outcome == 'success'
-        uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@v6
         with:
           failOnWarnings: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,23 @@ jobs:
   commitlint:
     name: Lint commit messages
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      # Add this step to check if the repository is accessible
+      # To be removed once the repository is public
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+        continue-on-error: true
+      - name: Warn if repository not accessible
+        if: steps.checkout.outcome == 'failure'
+        run: echo "::warning::Repository not accessible, skipping commitlint"
+      - name: Lint commit messages
+        if: steps.checkout.outcome == 'success'
+        uses: wagoid/commitlint-github-action@v6
         with:
           failOnWarnings: false
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ uv sync
 ```python
 from normalization import load_pipeline
 
-pipeline = load_pipeline("normalization/presets/gladia-3.yaml", language="en")
+# Load a built-in preset by name
+pipeline = load_pipeline("gladia-3", language="en")
 
 pipeline.normalize("It's $50 at 3:00PM")
 # => "it is 50 dollars at 3 pm"
@@ -118,10 +119,12 @@ stages:
     - normalize_whitespace
 ```
 
+_Load from your custom configuration:_
+
 ```python
 from normalization import load_pipeline
 
-pipeline = load_pipeline("path/to/my-preset-v1.yaml", language="en")
+pipeline = load_pipeline("path/to/my-custom-configuration.yaml", language="en")
 result = pipeline.normalize("some transcription text")
 ```
 

--- a/normalization/pipeline/loader.py
+++ b/normalization/pipeline/loader.py
@@ -9,16 +9,39 @@ from normalization.pipeline.base import NormalizationPipeline
 from normalization.steps import get_step_registry
 from normalization.steps.base import TextStep, WordStep
 
+_PRESETS_DIR = Path(__file__).parent.parent / "presets"
 
-def load_pipeline(yaml_path: str | Path, language: str) -> NormalizationPipeline:
+
+def _resolve_preset_path(preset: str | Path) -> Path:
+    path = Path(preset)
+    if path.exists() and path.is_file():
+        return path
+    if path.suffix in (".yaml", ".yml"):
+        raise FileNotFoundError(f"Preset file not found: {path}")
+    yaml_path = _PRESETS_DIR / f"{preset}.yaml"
+    if not yaml_path.exists():
+        available = [p.stem for p in _PRESETS_DIR.glob("*.yaml")]
+        raise FileNotFoundError(
+            f"No built-in preset named {preset!r}. Available presets: {available}"
+        )
+    return yaml_path
+
+
+def load_pipeline(preset: str | Path, language: str) -> NormalizationPipeline:
     """
-    Load a pipeline from a YAML preset file for a given language.
+    Load a pipeline for a given language.
 
-    The YAML defines which steps are active per stage.
+    ``preset`` can be:
+
+    - A preset name (e.g. ``"gladia-3"``): loads the corresponding YAML from
+      the package's built-in ``presets/`` directory.
+    - A path to a YAML file (e.g. ``"path/to/my-preset.yaml"``): loads that
+      file directly.
+
     Step ORDER within each stage is defined by the YAML list order,
     but the 3-stage structure (pre / word / post) is enforced.
     """
-    config = yaml.safe_load(Path(yaml_path).read_text())
+    config = yaml.safe_load(_resolve_preset_path(preset).read_text())
 
     language_registry = get_language_registry()
     operators = language_registry.get(language, language_registry["default"])()

--- a/tests/e2e/normalization_test.py
+++ b/tests/e2e/normalization_test.py
@@ -8,7 +8,6 @@ from normalization.pipeline.base import NormalizationPipeline
 from normalization.pipeline.loader import load_pipeline
 
 _FILES_DIR = Path(__file__).resolve().parent / "files"
-_PRESETS_DIR = Path(__file__).resolve().parents[2] / "normalization" / "presets"
 
 
 @dataclass
@@ -36,10 +35,10 @@ def _case_ids(cases: list[NormalizationTest]) -> list[str]:
     return [f"{test.language}:{test.input[:60]}" for test in cases]
 
 
-def _load_pipeline(preset_path: Path, language: str) -> NormalizationPipeline:
+def _load_pipeline(preset_name_or_path: str, language: str) -> NormalizationPipeline:
     if language not in _GLADIA_3_PIPELINES:
         _GLADIA_3_PIPELINES[language] = load_pipeline(
-            preset_path,
+            preset_name_or_path,
             language,
         )
     return _GLADIA_3_PIPELINES[language]
@@ -60,7 +59,7 @@ _GLADIA_3_PIPELINES: dict[str, NormalizationPipeline] = {}
     ids=_case_ids(_GLADIA_3_TESTS),
 )
 def test_gladia_3(test: NormalizationTest) -> None:
-    pipeline = _load_pipeline(_PRESETS_DIR / "gladia-3.yaml", test.language)
+    pipeline = _load_pipeline("gladia-3", test.language)
     result = pipeline.normalize(test.input)
     assert result == test.expected, (
         f"\n  input:    {test.input!r}"


### PR DESCRIPTION
Normalization presets are now loaded by name instad of its path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline loading now accepts preset names (e.g., "gladia-3") for built-in presets or direct paths to custom configuration files.

* **Documentation**
  * Updated usage examples to show loading built-in presets by name.
  * Added a "Load from your custom configuration" section with examples for using custom config paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->