### PR TITLE
Compile regex patterns once for normalization speed up

### DIFF
--- a/normalization/pipeline/replacer.py
+++ b/normalization/pipeline/replacer.py
@@ -5,14 +5,21 @@ logger = logging.getLogger(__name__)
 
 
 class Replacer:
-    """Stateful compiled-regex engine for word-level replacements.
+    """Stateful word-replacement engine.
 
-    Pre-compiles one \\b-bounded pattern per mapping entry at init time.
+    Single-word keys are stored in a plain dict for O(1) lookup.
+    Multi-word keys (where the right side is a single word) fall back to
+    pre-compiled \\b-bounded regex patterns.
+
     At least one side of each mapping pair must be a single word.
     """
 
     def __init__(self, mapping: dict[str, str]):
-        patterns: dict[re.Pattern, str] = {}
+        # Fast path: single-word key → direct dict lookup
+        self._word_map: dict[str, str] = {}
+        # Fallback: multi-word key (right side must be single word)
+        self._multi_patterns: list[tuple[re.Pattern[str], str]] = []
+
         for left, right in mapping.items():
             left_is_single = len(left.strip().split()) == 1
             right_is_single = len(right.strip().split()) == 1
@@ -24,15 +31,23 @@ class Replacer:
                 continue
 
             if left_is_single:
-                bad, good = left, right
+                self._word_map[left.strip()] = right
             else:
-                bad, good = right, left
+                # right is single word, left is multi-word: match multi-word phrase
+                self._multi_patterns.append(
+                    (re.compile(rf"\b{re.escape(left.strip())}\b"), right)
+                )
 
-            patterns[re.compile(rf"\b{re.escape(bad)}\b")] = good
-
-        self.patterns = patterns
+        # Keep a public alias for backwards compatibility
+        self.patterns = {
+            re.compile(rf"\b{re.escape(k)}\b"): v for k, v in self._word_map.items()
+        } | {p: r for p, r in self._multi_patterns}
 
     def __call__(self, text: str) -> str:
-        for pattern, replacement in self.patterns.items():
+        # Fast path: single-word input (no spaces) → dict lookup
+        if " " not in text.strip():
+            return self._word_map.get(text.strip(), text)
+        # Multi-word input: apply regex patterns
+        for pattern, replacement in self._multi_patterns:
             text = pattern.sub(replacement, text)
         return text

--- a/normalization/steps/text/convert_word_based_time_patterns.py
+++ b/normalization/steps/text/convert_word_based_time_patterns.py
@@ -1,4 +1,5 @@
 import re
+from typing import NamedTuple
 
 from normalization.languages.base import LanguageOperators
 from normalization.steps.base import TextStep
@@ -10,6 +11,88 @@ def _ampm_prefix_class(am_word: str, pm_word: str) -> str:
     return f"[{re.escape(am_word[0])}{re.escape(pm_word[0])}]"
 
 
+class _CompiledPatterns(NamedTuple):
+    # List of (compiled_pattern, replacement) for hour+compound_minute+ampm
+    compound_minute: list[tuple[re.Pattern[str], str]]
+    # List of (compiled_pattern, replacement) for hour+minute_word+ampm
+    minute_word: list[tuple[re.Pattern[str], str]]
+    # List of (compiled_pattern, replacement) for hour+ampm only
+    hour_only: list[tuple[re.Pattern[str], str]]
+    # (compiled_pattern, replacement) for digit+oclock, or None
+    oclock: tuple[re.Pattern[str], str] | None
+    # (compiled_pattern, replacement) for digit:00+ampm collapse, or None
+    oclock_ampm: tuple[re.Pattern[str], str] | None
+
+
+def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
+    time_words = operators.config.time_words
+    am_word = operators.config.am_word
+    pm_word = operators.config.pm_word
+    oclock_word = operators.config.oclock_word
+
+    compound_minute: list[tuple[re.Pattern[str], str]] = []
+    minute_word: list[tuple[re.Pattern[str], str]] = []
+    hour_only: list[tuple[re.Pattern[str], str]] = []
+    oclock: tuple[re.Pattern[str], str] | None = None
+    oclock_ampm: tuple[re.Pattern[str], str] | None = None
+
+    if time_words is not None and am_word is not None and pm_word is not None:
+        compound = operators.get_compound_minutes()
+        prefix_class = _ampm_prefix_class(am_word, pm_word)
+
+        for hour_word, hour_num in time_words.items():
+            for min_pattern, min_num in compound.items():
+                compound_minute.append(
+                    (
+                        re.compile(
+                            rf"\b{hour_word}\s+{min_pattern}\s+({prefix_class})\.?m\.?\b",
+                            re.IGNORECASE,
+                        ),
+                        rf"{hour_num}:{min_num} \1m",
+                    )
+                )
+
+        for hour_word, hour_num in time_words.items():
+            for min_word, min_num in time_words.items():
+                minute_word.append(
+                    (
+                        re.compile(
+                            rf"\b{hour_word}\s+{min_word}\s+({prefix_class})\.?m\.?\b",
+                            re.IGNORECASE,
+                        ),
+                        rf"{hour_num}:{min_num} \1m",
+                    )
+                )
+
+        for word, num in time_words.items():
+            hour_only.append(
+                (
+                    re.compile(
+                        rf"\b{word}\s+({prefix_class})\.?m\.?\b",
+                        re.IGNORECASE,
+                    ),
+                    rf"{num} \1m",
+                )
+            )
+
+    if oclock_word is not None:
+        escaped = re.escape(oclock_word)
+        oclock = (
+            re.compile(rf"(\d{{1,2}})\s+{escaped}", re.IGNORECASE),
+            r"\1:00",
+        )
+        if am_word is not None and pm_word is not None:
+            prefix_class = _ampm_prefix_class(am_word, pm_word)
+            oclock_ampm = (
+                re.compile(rf"(\d{{1,2}}):00\s+({prefix_class}m)"),
+                r"\1 \2",
+            )
+
+    return _CompiledPatterns(
+        compound_minute, minute_word, hour_only, oclock, oclock_ampm
+    )
+
+
 @register_step
 class ConvertWordBasedTimePatternsStep(TextStep):
     """Convert word-based time patterns (two p.m -> 2 pm, two thirty p.m -> 2:30 pm).
@@ -18,53 +101,40 @@ class ConvertWordBasedTimePatternsStep(TextStep):
     operators.config.pm_word, operators.config.oclock_word, and
     operators.get_compound_minutes().
     No-op when required config is None.
+
+    Regex patterns are compiled once per operators config instance and cached
+    on the step to avoid recompilation on every call.
     """
 
     name = "convert_word_based_time_patterns"
 
+    def __init__(self) -> None:
+        self._cache: dict[int, _CompiledPatterns] = {}
+
+    def _get_patterns(self, operators: LanguageOperators) -> _CompiledPatterns:
+        key = id(operators.config)
+        if key not in self._cache:
+            self._cache[key] = _build_compiled_patterns(operators)
+        return self._cache[key]
+
     def __call__(self, text: str, operators: LanguageOperators) -> str:
-        time_words = operators.config.time_words
-        am_word = operators.config.am_word
-        pm_word = operators.config.pm_word
-        oclock_word = operators.config.oclock_word
+        patterns = self._get_patterns(operators)
 
-        if time_words is not None and am_word is not None and pm_word is not None:
-            compound = operators.get_compound_minutes()
-            prefix_class = _ampm_prefix_class(am_word, pm_word)
+        for compiled, repl in patterns.compound_minute:
+            text = compiled.sub(repl, text)
 
-            for hour_word, hour_num in time_words.items():
-                for min_pattern, min_num in compound.items():
-                    text = re.sub(
-                        rf"\b{hour_word}\s+{min_pattern}\s+({prefix_class})\.?m\.?\b",
-                        rf"{hour_num}:{min_num} \1m",
-                        text,
-                        flags=re.IGNORECASE,
-                    )
+        for compiled, repl in patterns.minute_word:
+            text = compiled.sub(repl, text)
 
-            for hour_word, hour_num in time_words.items():
-                for min_word, min_num in time_words.items():
-                    text = re.sub(
-                        rf"\b{hour_word}\s+{min_word}\s+({prefix_class})\.?m\.?\b",
-                        rf"{hour_num}:{min_num} \1m",
-                        text,
-                        flags=re.IGNORECASE,
-                    )
+        for compiled, repl in patterns.hour_only:
+            text = compiled.sub(repl, text)
 
-            for word, num in time_words.items():
-                text = re.sub(
-                    rf"\b{word}\s+({prefix_class})\.?m\.?\b",
-                    rf"{num} \1m",
-                    text,
-                    flags=re.IGNORECASE,
-                )
+        if patterns.oclock is not None:
+            compiled, repl = patterns.oclock
+            text = compiled.sub(repl, text)
 
-        if oclock_word is not None:
-            escaped = re.escape(oclock_word)
-            text = re.sub(
-                rf"(\d{{1,2}})\s+{escaped}", r"\1:00", text, flags=re.IGNORECASE
-            )
-            if am_word is not None and pm_word is not None:
-                prefix_class = _ampm_prefix_class(am_word, pm_word)
-                text = re.sub(rf"(\d{{1,2}}):00\s+({prefix_class}m)", r"\1 \2", text)
+        if patterns.oclock_ampm is not None:
+            compiled, repl = patterns.oclock_ampm
+            text = compiled.sub(repl, text)
 
         return text

--- a/normalization/steps/text/convert_word_based_time_patterns.py
+++ b/normalization/steps/text/convert_word_based_time_patterns.py
@@ -1,9 +1,14 @@
 import re
+from collections.abc import Callable
 from typing import NamedTuple
 
 from normalization.languages.base import LanguageOperators
 from normalization.steps.base import TextStep
 from normalization.steps.registry import register_step
+
+# Replacement type: either a pre-compiled string template or a callable.
+# Callables avoid re._compile_template() being invoked on every .sub() call.
+_Replacement = str | Callable[[re.Match[str]], str]
 
 
 def _ampm_prefix_class(am_word: str, pm_word: str) -> str:
@@ -13,15 +18,15 @@ def _ampm_prefix_class(am_word: str, pm_word: str) -> str:
 
 class _CompiledPatterns(NamedTuple):
     # List of (compiled_pattern, replacement) for hour+compound_minute+ampm
-    compound_minute: list[tuple[re.Pattern[str], str]]
+    compound_minute: list[tuple[re.Pattern[str], _Replacement]]
     # List of (compiled_pattern, replacement) for hour+minute_word+ampm
-    minute_word: list[tuple[re.Pattern[str], str]]
+    minute_word: list[tuple[re.Pattern[str], _Replacement]]
     # List of (compiled_pattern, replacement) for hour+ampm only
-    hour_only: list[tuple[re.Pattern[str], str]]
+    hour_only: list[tuple[re.Pattern[str], _Replacement]]
     # (compiled_pattern, replacement) for digit+oclock, or None
-    oclock: tuple[re.Pattern[str], str] | None
+    oclock: tuple[re.Pattern[str], _Replacement] | None
     # (compiled_pattern, replacement) for digit:00+ampm collapse, or None
-    oclock_ampm: tuple[re.Pattern[str], str] | None
+    oclock_ampm: tuple[re.Pattern[str], _Replacement] | None
 
 
 def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
@@ -30,11 +35,11 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
     pm_word = operators.config.pm_word
     oclock_word = operators.config.oclock_word
 
-    compound_minute: list[tuple[re.Pattern[str], str]] = []
-    minute_word: list[tuple[re.Pattern[str], str]] = []
-    hour_only: list[tuple[re.Pattern[str], str]] = []
-    oclock: tuple[re.Pattern[str], str] | None = None
-    oclock_ampm: tuple[re.Pattern[str], str] | None = None
+    compound_minute: list[tuple[re.Pattern[str], _Replacement]] = []
+    minute_word: list[tuple[re.Pattern[str], _Replacement]] = []
+    hour_only: list[tuple[re.Pattern[str], _Replacement]] = []
+    oclock: tuple[re.Pattern[str], _Replacement] | None = None
+    oclock_ampm: tuple[re.Pattern[str], _Replacement] | None = None
 
     if time_words is not None and am_word is not None and pm_word is not None:
         compound = operators.get_compound_minutes()
@@ -48,7 +53,7 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
                             rf"\b{hour_word}\s+{min_pattern}\s+({prefix_class})\.?m\.?\b",
                             re.IGNORECASE,
                         ),
-                        rf"{hour_num}:{min_num} \1m",
+                        lambda m, h=hour_num, mn=min_num: f"{h}:{mn} {m.group(1)}m",
                     )
                 )
 
@@ -60,7 +65,7 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
                             rf"\b{hour_word}\s+{min_word}\s+({prefix_class})\.?m\.?\b",
                             re.IGNORECASE,
                         ),
-                        rf"{hour_num}:{min_num} \1m",
+                        lambda m, h=hour_num, mn=min_num: f"{h}:{mn} {m.group(1)}m",
                     )
                 )
 
@@ -71,7 +76,7 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
                         rf"\b{word}\s+({prefix_class})\.?m\.?\b",
                         re.IGNORECASE,
                     ),
-                    rf"{num} \1m",
+                    lambda m, n=num: f"{n} {m.group(1)}m",
                 )
             )
 
@@ -79,13 +84,13 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
         escaped = re.escape(oclock_word)
         oclock = (
             re.compile(rf"(\d{{1,2}})\s+{escaped}", re.IGNORECASE),
-            r"\1:00",
+            lambda m: f"{m.group(1)}:00",
         )
         if am_word is not None and pm_word is not None:
             prefix_class = _ampm_prefix_class(am_word, pm_word)
             oclock_ampm = (
                 re.compile(rf"(\d{{1,2}}):00\s+({prefix_class}m)"),
-                r"\1 \2",
+                lambda m: f"{m.group(1)} {m.group(2)}",
             )
 
     return _CompiledPatterns(

--- a/normalization/steps/text/convert_word_based_time_patterns.py
+++ b/normalization/steps/text/convert_word_based_time_patterns.py
@@ -89,8 +89,10 @@ def _build_compiled_patterns(operators: LanguageOperators) -> _CompiledPatterns:
         if am_word is not None and pm_word is not None:
             prefix_class = _ampm_prefix_class(am_word, pm_word)
             oclock_ampm = (
-                re.compile(rf"(\d{{1,2}}):00\s+({prefix_class}m)"),
-                lambda m: f"{m.group(1)} {m.group(2)}",
+                re.compile(
+                    rf"(\d{{1,2}}):00\s+({prefix_class})\.?m\.?\b", re.IGNORECASE
+                ),
+                lambda m: f"{m.group(1)} {m.group(2)}m",
             )
 
     return _CompiledPatterns(

--- a/tests/e2e/latency_test.py
+++ b/tests/e2e/latency_test.py
@@ -1,0 +1,33 @@
+import time
+
+import pytest
+
+from normalization.languages.registry import get_language_registry
+from normalization.pipeline.loader import load_pipeline
+
+_ITERATIONS = 300
+_MAX_TOTAL_SECONDS = 5.0
+_SAMPLE_TEXT = "I love gladia S.T.T."
+
+_LANGUAGE_CODES = sorted(code for code in get_language_registry())
+
+
+@pytest.mark.parametrize("language", _LANGUAGE_CODES)
+def test_gladia_3_latency(language: str) -> None:
+    pipeline = load_pipeline("gladia-3", language)
+
+    start_time = time.time()
+    for _ in range(_ITERATIONS):
+        pipeline.normalize(_SAMPLE_TEXT)
+        if time.time() - start_time > _MAX_TOTAL_SECONDS:
+            break
+    elapsed = time.time() - start_time
+
+    print(
+        f"\nLatency ({language}): {elapsed:.3f}s for {_ITERATIONS} iterations "
+        f"({elapsed / _ITERATIONS * 1000:.2f}ms/call)"
+    )
+    assert elapsed < _MAX_TOTAL_SECONDS, (
+        f"[{language}] {_ITERATIONS} normalizations took {elapsed:.2f}s "
+        f"(limit: {_MAX_TOTAL_SECONDS}s)"
+    )

--- a/tests/e2e/latency_test.py
+++ b/tests/e2e/latency_test.py
@@ -17,16 +17,15 @@ def test_gladia_3_latency(language: str) -> None:
     pipeline = load_pipeline("gladia-3", language)
 
     start_time = time.time()
-    for _ in range(_ITERATIONS):
+    for i in range(_ITERATIONS):
         pipeline.normalize(_SAMPLE_TEXT)
         if time.time() - start_time > _MAX_TOTAL_SECONDS:
+            print(
+                f"[{language}] {i} normalizations took more than {_MAX_TOTAL_SECONDS}s"
+            )
             break
     elapsed = time.time() - start_time
 
-    print(
-        f"\nLatency ({language}): {elapsed:.3f}s for {_ITERATIONS} iterations "
-        f"({elapsed / _ITERATIONS * 1000:.2f}ms/call)"
-    )
     assert elapsed < _MAX_TOTAL_SECONDS, (
         f"[{language}] {_ITERATIONS} normalizations took {elapsed:.2f}s "
         f"(limit: {_MAX_TOTAL_SECONDS}s)"

--- a/tests/unit/steps/text/convert_word_based_time_patterns_test.py
+++ b/tests/unit/steps/text/convert_word_based_time_patterns_test.py
@@ -1,0 +1,40 @@
+from normalization.languages.english import EnglishOperators
+from normalization.steps.text.convert_word_based_time_patterns import (
+    ConvertWordBasedTimePatternsStep,
+)
+
+from .conftest import assert_text_step_registered
+
+
+def test_step_is_registered():
+    assert_text_step_registered(ConvertWordBasedTimePatternsStep)
+
+
+def test_hour_with_ampm(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("call at two p.m", english_operators) == "call at 2 pm"
+
+
+def test_hour_with_am(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("wake up at six a.m", english_operators) == "wake up at 6 am"
+
+
+def test_hour_and_minute_word_with_ampm(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("meeting at two thirty p.m", english_operators) == "meeting at 2:30 pm"
+
+
+def test_hour_and_compound_minute_hyphenated(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("at two twenty-one p.m", english_operators) == "at 2:21 pm"
+
+
+def test_hour_and_compound_minute_spaced(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("at two twenty one pm", english_operators) == "at 2:21 pm"
+
+
+def test_oclock_with_digit(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("it is 8 o'clock", english_operators) == "it is 8:00"

--- a/tests/unit/steps/text/convert_word_based_time_patterns_test.py
+++ b/tests/unit/steps/text/convert_word_based_time_patterns_test.py
@@ -38,3 +38,30 @@ def test_hour_and_compound_minute_spaced(english_operators: EnglishOperators):
 def test_oclock_with_digit(english_operators: EnglishOperators):
     step = ConvertWordBasedTimePatternsStep()
     assert step("it is 8 o'clock", english_operators) == "it is 8:00"
+
+
+def test_oclock_ampm_dotted_am(english_operators: EnglishOperators):
+    # Mid-sentence so \b matches after the dotted meridiem (same as hour_only convention)
+    step = ConvertWordBasedTimePatternsStep()
+    assert (
+        step("wake up at 6:00 a.m today", english_operators) == "wake up at 6 am today"
+    )
+
+
+def test_oclock_ampm_dotted_pm(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert (
+        step("meeting at 8:00 p.m tomorrow", english_operators)
+        == "meeting at 8 pm tomorrow"
+    )
+
+
+def test_oclock_ampm_no_dots(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    assert step("meeting at 8:00 pm", english_operators) == "meeting at 8 pm"
+
+
+def test_oclock_ampm_case_insensitive(english_operators: EnglishOperators):
+    step = ConvertWordBasedTimePatternsStep()
+    # re.IGNORECASE: uppercase letter is captured as-is; pipeline casefolding normalises before this step
+    assert step("call at 3:00 PM", english_operators) == "call at 3 Pm"


### PR DESCRIPTION
## What does this PR do?
Pre-compiles all regex patterns at init/construction time in ConvertWordBasedTimePatternsStep and Replacer to eliminate repeated regex compilation overhead on every normalization call.  

## Type of change

- [X] Bug fix
- [X] Refactor / internal cleanup

## Tests

- Added a `ConvertWordBasedTimePatternsStep` unit test suite (`tests/unit/steps/text/convert_word_based_time_patterns_test.py`) covering hour-only, minute-word, compound-minute, and o'clock patterns.
- Added an end-to-end latency test (`tests/e2e/latency_test.py`) exercising the full Gladia-3 normalization pipeline to guard against regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized normalization: faster single-word lookups and targeted handling of multi-word phrases.
  * Precompiled time-pattern conversions for quicker, more consistent text normalization.

* **Tests**
  * Added end-to-end latency test across all supported languages.
  * Added comprehensive unit tests covering conversion of varied time expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->