### PR TITLE
fix: update german normalization after voxpopuli

### DIFF
--- a/normalization/languages/german/replacements.py
+++ b/normalization/languages/german/replacements.py
@@ -1,4 +1,9 @@
 GERMAN_REPLACEMENTS: dict[str, str] = {
+    # Colloquial / ASR variants (VoxPopuli DE)
+    "einmal": "mal",
+    "eines": "eins",
+    "konnt": "konnen",
+    "kottonou": "cotonou",
     "u.": "unter",
     "chr.": "christus",
     "rissströmungen": "riss-strömungen",

--- a/normalization/languages/german/sentence_replacements.py
+++ b/normalization/languages/german/sentence_replacements.py
@@ -1,4 +1,7 @@
 GERMAN_SENTENCE_REPLACEMENTS: dict[str, str] = {
+    # VoxPopuli DE: split compound / expanded policy term
+    "nun mehr": "nunmehr",
+    "handelspolitik und entwicklungspolitik": "handels und entwicklungspolitik",
     "regimeet kritischen": "regimekritischen",
     "cannabis joints": "cannabisjoints",
     "kampf handlungen": "kampfhandlungen",

--- a/tests/unit/languages/german_voxpopuli_normalization_test.py
+++ b/tests/unit/languages/german_voxpopuli_normalization_test.py
@@ -1,0 +1,43 @@
+import pytest
+
+from normalization.pipeline.loader import load_pipeline
+
+
+@pytest.fixture
+def pipeline():
+    return load_pipeline("gladia-3", "de")
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("irgendwann einmal", "irgendwann mal"),
+        ("irgendwann mal", "irgendwann mal"),
+        ("noch eines sagen", "noch eins sagen"),
+        ("noch eins sagen", "noch eins sagen"),
+        ("nunmehr", "nunmehr"),
+        ("nun mehr", "nunmehr"),
+        ("können", "konnen"),
+        ("könnt", "konnen"),
+        (
+            "handels und entwicklungspolitik",
+            "handels und entwicklungspolitik",
+        ),
+        (
+            "handelspolitik und entwicklungspolitik",
+            "handels und entwicklungspolitik",
+        ),
+        ("cotonou", "cotonou"),
+        ("kottonou", "cotonou"),
+        ("zweitausendsieben", "2007"),
+        ("zwotausendsieben", "2007"),
+        ("2007", "2007"),
+    ],
+)
+def test_voxpopuli_german_aliases(pipeline, raw, expected):
+    assert pipeline.normalize(raw) == expected
+
+
+def test_mal_particle_not_expanded_to_einmal(pipeline):
+    """Colloquial particle 'mal' must stay when it is not 'einmal'."""
+    assert pipeline.normalize("halt mal so") == "mal so"


### PR DESCRIPTION
## What does this PR do?

Mainly add replacements 

## Type of change

- [ ] New language
- [x] Edit existing language (fix a replacement, tweak config, …)
- [ ] New normalization step
- [ ] Edit existing step (bug fix, behaviour change)
- [ ] New preset version
- [ ] Bug fix (other)
- [ ] Refactor / docs / CI

---

## Checklist

**Only fill in the section(s) that match your change — delete the rest.**

### Edit existing language

- [x] New/changed word substitutions go in `replacements.py`, not inline in `operators.py`
- [x] If you changed a config field that can be `None`: the step reading it still handles `None` gracefully
- [x] Unit tests updated or added
- [x] E2e CSV updated if the expected output changed


## How was this tested?

```
uv run pytest tests/
```
